### PR TITLE
Add possibility to add 2 batteries in one card + additional configuration posibilities 

### DIFF
--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -72,7 +72,7 @@ class JbBatteryCard extends HTMLElement {
             --base-unit: ${cardConfig.scale};
             cursor: pointer;
             display: flex;
-            flex-direction: ${cardConfig.horizontal === false ? 'column' : 'row'};
+            flex-direction: row;
             align-items: center;
             text-align: center;
             padding: 4% 0px;
@@ -210,6 +210,15 @@ class JbBatteryCard extends HTMLElement {
         return entity.attributes ? entity.attributes[attribute] : null;
     }
 
+    // --- Funktion um Wert mit Pfeil anzuzeigen ---
+    _formatValueWithArrow(value) {
+        if (value === null || value === undefined) return '';
+        const rounded = Math.round(value);
+        if (rounded < 0) return `↑${Math.abs(rounded)}`;
+        if (rounded > 0) return `↓${rounded}`;
+        return `${rounded}`;
+    }
+
     set hass(hass) {
         const root = this.shadowRoot;
         const config = this._config;
@@ -225,7 +234,7 @@ class JbBatteryCard extends HTMLElement {
         if (config.value1_entity) {
             const value1 = this._getEntityStateValue(hass.states[config.value1_entity]);
             root.getElementById("value1").textContent = (value1 !== null && value1 !== undefined) 
-                ? `${Math.round(value1)} ${config.value1_unit || ''}` 
+                ? `${this._formatValueWithArrow(value1)}${config.value1_unit || ''}` 
                 : '';
         }
 
@@ -241,7 +250,7 @@ class JbBatteryCard extends HTMLElement {
             if (config.value2_entity) {
                 const value2 = this._getEntityStateValue(hass.states[config.value2_entity]);
                 root.getElementById("value2").textContent = (value2 !== null && value2 !== undefined) 
-                    ? `${Math.round(value2)} ${config.value2_unit || ''}` 
+                    ? `${this._formatValueWithArrow(value2)}${config.value2_unit || ''}` 
                     : '';
             }
         }
@@ -254,5 +263,5 @@ class JbBatteryCard extends HTMLElement {
     }
 }
 
-console.log("%c 🪫 jb-battery-card (2 Sensors + optional value + unit, integer display) ", "background: #222; color: #bada55");
+console.log("%c 🪫 jb-battery-card (2 Sensors + optional value + unit, arrows for +/-) ", "background: #222; color: #bada55");
 customElements.define("jb-battery-card", JbBatteryCard);

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -30,7 +30,7 @@ class JbBatteryCard extends HTMLElement {
 
     setConfig(config) {
         if (!config.entity) {
-            throw new Error("Please define an entity");
+            throw new Error("Please define entity");
         }
 
         const root = this.shadowRoot;
@@ -39,74 +39,108 @@ class JbBatteryCard extends HTMLElement {
         const cardConfig = Object.assign({}, config);
         if (!cardConfig.scale) cardConfig.scale = "50px";
 
+        // Entity 1
         const entityParts = this._splitEntityAndAttribute(cardConfig.entity);
-        const statusEntityParts = this._splitEntityAndAttribute(cardConfig.entity.replace("_level", "_state"));
         cardConfig.entity = entityParts.entity;
-        cardConfig.status_entity = statusEntityParts.entity;
+        if (entityParts.attribute) cardConfig.attribute1 = entityParts.attribute;
 
-        if (entityParts.attribute) cardConfig.attribute = entityParts.attribute;
-        if (statusEntityParts.attribute) cardConfig.status_attribute = statusEntityParts.attribute;
+        // Optionaler Wert 1 (Entladeleistung)
+        if (!cardConfig.value1_entity) cardConfig.value1_entity = null;
+        if (!cardConfig.value1_unit) cardConfig.value1_unit = '';
+
+        // Entity 2 (optional)
+        let entity2Parts = null;
+        if (cardConfig.entity2) {
+            entity2Parts = this._splitEntityAndAttribute(cardConfig.entity2);
+            cardConfig.entity2 = entity2Parts.entity;
+            if (entity2Parts.attribute) cardConfig.attribute2 = entity2Parts.attribute;
+
+            if (!cardConfig.value2_entity) cardConfig.value2_entity = null;
+            if (!cardConfig.value2_unit) cardConfig.value2_unit = '';
+        }
 
         const card = document.createElement("ha-card");
         card.setAttribute("id", "card");
-        card.setAttribute("aria-label", cardConfig.title);
+        card.setAttribute("aria-label", cardConfig.title || "");
 
-        if (cardConfig.horizontal === true) {
-            card.classList.add("horizontal");
-        }
+        // Dynamische Icon-Größe: 1 Batterie → 40%, 2 Batterien → 80%
+        const iconSize = cardConfig.entity2 ? '80%' : '40%';
 
         const style = document.createElement("style");
         style.textContent = `
-      
           ha-card {
             --base-unit: ${cardConfig.scale};
             cursor: pointer;
             display: flex;
-            flex-direction: column;
+            flex-direction: row;
             align-items: center;
             text-align: center;
             padding: 4% 0px;
             font-size: 16.8px;
             box-sizing: border-box;
-            justify-content: center;
             justify-content: space-evenly;
-            position: relative;
-            overflow: hidden;
             height: 100%;
           }
             
           ha-icon {
-              width: 40%;
+              width: ${iconSize};
               height: auto;
               --mdc-icon-size: 100%;
           }
           
-          #description {
+          .battery-block {
               display: flex;
               flex-direction: column;
+              align-items: center;
+              margin: 0 10px;
           }
-          
-          ha-card.horizontal {
-            flex-direction: row;
-            justify-content: space-evenly;
+
+          .extra-value {
+              font-size: 0.9em;
+              color: var(--primary-text-color);
+              margin: 2px 0;
           }
         `;
 
+        // HTML mit optionalen Titeln und extra Wert
         card.innerHTML = `
-        <ha-icon id="icon" icon="mdi:battery" style="margin-right: 0px"></ha-icon>
-        <div id="description">
-            <span id="title"></span> <span id="percent"></span>
+        <div class="battery-block" id="battery1">
+            <ha-icon id="icon1" icon="mdi:battery"></ha-icon>
+            <div id="description1">
+                ${cardConfig.title1 ? `<span id="title1">${cardConfig.title1}</span>` : ''}
+                <span class="extra-value" id="value1"></span>
+                <span id="percent1">-</span>
+            </div>
         </div>
+        ${cardConfig.entity2 ? `
+        <div class="battery-block" id="battery2">
+            <ha-icon id="icon2" icon="mdi:battery"></ha-icon>
+            <div id="description2">
+                ${cardConfig.title2 ? `<span id="title2">${cardConfig.title2}</span>` : ''}
+                <span class="extra-value" id="value2"></span>
+                <span id="percent2">-</span>
+            </div>
+        </div>` : ''}
         <mwc-ripple></mwc-ripple>
         `;
 
         card.appendChild(style);
-        card.addEventListener("click", event => {
+
+        // Klick auf Batterie 1
+        card.querySelector("#battery1").addEventListener("click", event => {
             this._fire("hass-more-info", { entityId: cardConfig.entity });
         });
 
+        // Klick auf Batterie 2
+        if (cardConfig.entity2) {
+            card.querySelector("#battery2").addEventListener("click", event => {
+                this._fire("hass-more-info", { entityId: cardConfig.entity2 });
+            });
+        }
+
         root.appendChild(card);
 
+        // Farbskala
         if (cardConfig.colors) {
             this.colorMap = cardConfig.colors;
         } else if (cardConfig.variant == "simple") {
@@ -123,7 +157,6 @@ class JbBatteryCard extends HTMLElement {
         if (parts.length < 3) {
             return { entity: entity };
         }
-
         return { attribute: parts.pop(), entity: parts.join(".") };
     }
 
@@ -143,90 +176,83 @@ class JbBatteryCard extends HTMLElement {
 
     _computeColor(stateValue) {
         let numberValue = Number(stateValue);
-        let colorLevels = Object.keys(this.colorMap).sort().reverse();
-        let key = colorLevels.find(key => {
-            if (numberValue >= key) {
-                return key;
-            }
-        });
+        let colorLevels = Object.keys(this.colorMap).sort((a,b) => b-a);
+        let key = colorLevels.find(key => numberValue >= key);
         return this.colorMap[key];
     }
 
     _computeBatteryIconSimple(value, state) {
-        let statePart = "";
-        if (state === "charging" || state === "full") {
-            statePart = "-charging";
-        }
-        
+        let statePart = (state === "charging" || state === "full") ? "-charging" : "";
         let level = +value;
-        if (level <= 15) {
-            return `mdi:battery${statePart}-outline`;
-        } else if (level <= 45) {
-            return `mdi:battery${statePart}-low`;
-        } else if (level <= 80) {
-            return `mdi:battery${statePart}-medium`;
-        } else if (level > 80) {
-            return `mdi:battery${statePart}-high`;
-        } else {
-            return `mdi:battery${statePart}`;
-        }
+        if (level <= 15) return `mdi:battery${statePart}-outline`;
+        if (level <= 45) return `mdi:battery${statePart}-low`;
+        if (level <= 80) return `mdi:battery${statePart}-medium`;
+        return `mdi:battery${statePart}-high`;
     }
 
     _computeBatteryIconDetailed(value, state) {
-        let statePart = "";
-        if (state === "charging" || state === "full") {
-            statePart = "-charging";
-        }
-
+        let statePart = (state === "charging" || state === "full") ? "-charging" : "";
         let numberValue = +value;
         let level = Math.round(numberValue / 10) * 10;
-        if (level == 0) {
-            return `mdi:battery${statePart}-outline`;
-        } else if (level < 100) {
-            return `mdi:battery${statePart}-${level}`;
-        } else {
-            if (state === "charging" || state === "full") {
-                return `mdi:battery-charging-100`;
-            } else {
-                return `mdi:battery${statePart}`;
-            }
-        }
+        if (level == 0) return `mdi:battery${statePart}-outline`;
+        if (level < 100) return `mdi:battery${statePart}-${level}`;
+        return (state === "charging" || state === "full") ? `mdi:battery-charging-100` : `mdi:battery${statePart}`;
     }
 
     _computeBatteryIcon(value, state) {
-        if (this._config.variant == "simple") {
-            return this._computeBatteryIconSimple(value, state);
-        }
+        if (this._config.variant == "simple") return this._computeBatteryIconSimple(value, state);
         return this._computeBatteryIconDetailed(value, state);
     }
 
     _getEntityStateValue(entity, attribute) {
-        if (!attribute) {
-            return entity.state;
-        }
+        if (!entity) return null;
+        if (!attribute) return entity.state;
+        return entity.attributes ? entity.attributes[attribute] : null;
+    }
 
-        return entity.attributes[attribute];
+    // --- Funktion um Wert mit Pfeil anzuzeigen ---
+    _formatValueWithArrow(value) {
+        if (value === null || value === undefined) return '';
+        const rounded = Math.round(value);
+        if (rounded < 0) return `↑${Math.abs(rounded)}`;
+        if (rounded > 0) return `↓${rounded}`;
+        return `${rounded}`;
     }
 
     set hass(hass) {
         const root = this.shadowRoot;
-
         const config = this._config;
-        const entityState = parseInt(this._getEntityStateValue(hass.states[config.entity], config.attribute), 10) || '-';
-        const statusEntityState = this._getEntityStateValue(hass.states[config.status_entity], config.status_attribute);
 
-        const changed = statusEntityState !== this._statusEntityState || entityState !== this._entityState;
+        // --- Batterie 1 ---
+        const entityState1Raw = this._getEntityStateValue(hass.states[config.entity], config.attribute1);
+        const entityState1 = entityState1Raw !== null ? parseInt(entityState1Raw, 10) : '-';
+        const statusEntityState1 = this._getEntityStateValue(hass.states[config.entity], config.status_attribute1);
+        root.getElementById("percent1").textContent = `${entityState1}%`;
+        root.getElementById("icon1").setAttribute("icon", this._computeBatteryIcon(entityState1, statusEntityState1));
+        root.getElementById("icon1").style.color = this._computeColor(entityState1);
 
-        if (entityState !== this._entityState) {
-            root.getElementById("percent").textContent = `${entityState}%`;
-            root.getElementById("title").textContent = config.title;
-            this._entityState = entityState;
+        if (config.value1_entity) {
+            const value1 = this._getEntityStateValue(hass.states[config.value1_entity]);
+            root.getElementById("value1").textContent = (value1 !== null && value1 !== undefined) 
+                ? `${this._formatValueWithArrow(value1)}${config.value1_unit || ''}` 
+                : '';
         }
 
-        if (changed) {
-            root.getElementById("icon").setAttribute("icon", this._computeBatteryIcon(this._entityState, statusEntityState));
-            root.getElementById("icon").style.color = this._computeColor(this._entityState);
-            this._statusEntityState = statusEntityState;
+        // --- Batterie 2 ---
+        if (config.entity2) {
+            const entityState2Raw = this._getEntityStateValue(hass.states[config.entity2], config.attribute2);
+            const entityState2 = entityState2Raw !== null ? parseInt(entityState2Raw, 10) : '-';
+            const statusEntityState2 = this._getEntityStateValue(hass.states[config.entity2], config.status_attribute2);
+            root.getElementById("percent2").textContent = `${entityState2}%`;
+            root.getElementById("icon2").setAttribute("icon", this._computeBatteryIcon(entityState2, statusEntityState2));
+            root.getElementById("icon2").style.color = this._computeColor(entityState2);
+
+            if (config.value2_entity) {
+                const value2 = this._getEntityStateValue(hass.states[config.value2_entity]);
+                root.getElementById("value2").textContent = (value2 !== null && value2 !== undefined) 
+                    ? `${this._formatValueWithArrow(value2)}${config.value2_unit || ''}` 
+                    : '';
+            }
         }
 
         root.lastChild.hass = hass;
@@ -237,5 +263,5 @@ class JbBatteryCard extends HTMLElement {
     }
 }
 
-console.log("%c 🪫 jb-batter-card ", "background: #222; color: #bada55");
+console.log("%c 🪫 jb-battery-card (2 Sensors + optional value + unit, arrows for +/-) ", "background: #222; color: #bada55");
 customElements.define("jb-battery-card", JbBatteryCard);

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -56,6 +56,9 @@ class JbBatteryCard extends HTMLElement {
         card.setAttribute("id", "card");
         card.setAttribute("aria-label", cardConfig.title);
 
+        // Dynamische Icon-Größe: 1 Batterie → 40%, 2 Batterien → 80%
+        const iconSize = cardConfig.entity2 ? '80%' : '40%';
+
         const style = document.createElement("style");
         style.textContent = `
           ha-card {
@@ -73,7 +76,7 @@ class JbBatteryCard extends HTMLElement {
           }
             
           ha-icon {
-              width: auto;
+              width: ${iconSize};
               height: auto;
               --mdc-icon-size: 100%;
           }
@@ -86,6 +89,7 @@ class JbBatteryCard extends HTMLElement {
           }
         `;
 
+        // HTML mit optionalen Titeln
         card.innerHTML = `
         <div class="battery-block" id="battery1">
             <ha-icon id="icon1" icon="mdi:battery"></ha-icon>
@@ -105,7 +109,6 @@ class JbBatteryCard extends HTMLElement {
         <mwc-ripple></mwc-ripple>
         `;
 
-
         card.appendChild(style);
 
         // Klick auf Batterie 1
@@ -122,6 +125,7 @@ class JbBatteryCard extends HTMLElement {
 
         root.appendChild(card);
 
+        // Farbskala
         if (cardConfig.colors) {
             this.colorMap = cardConfig.colors;
         } else if (cardConfig.variant == "simple") {

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -73,7 +73,7 @@ class JbBatteryCard extends HTMLElement {
           }
             
           ha-icon {
-              width: 80%;
+              width: auto;
               height: auto;
               --mdc-icon-size: 100%;
           }

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -61,7 +61,7 @@ class JbBatteryCard extends HTMLElement {
 
         const card = document.createElement("ha-card");
         card.setAttribute("id", "card");
-        card.setAttribute("aria-label", cardConfig.title);
+        card.setAttribute("aria-label", cardConfig.title || "");
 
         // Dynamische Icon-Größe: 1 Batterie → 40%, 2 Batterien → 80%
         const iconSize = cardConfig.entity2 ? '80%' : '40%';
@@ -72,7 +72,7 @@ class JbBatteryCard extends HTMLElement {
             --base-unit: ${cardConfig.scale};
             cursor: pointer;
             display: flex;
-            flex-direction: row;
+            flex-direction: ${cardConfig.horizontal === false ? 'column' : 'row'};
             align-items: center;
             text-align: center;
             padding: 4% 0px;
@@ -176,7 +176,7 @@ class JbBatteryCard extends HTMLElement {
 
     _computeColor(stateValue) {
         let numberValue = Number(stateValue);
-        let colorLevels = Object.keys(this.colorMap).sort().reverse();
+        let colorLevels = Object.keys(this.colorMap).sort((a,b) => b-a);
         let key = colorLevels.find(key => numberValue >= key);
         return this.colorMap[key];
     }
@@ -205,9 +205,9 @@ class JbBatteryCard extends HTMLElement {
     }
 
     _getEntityStateValue(entity, attribute) {
-        if (!entity) return '-';
+        if (!entity) return null;
         if (!attribute) return entity.state;
-        return entity.attributes ? entity.attributes[attribute] : '-';
+        return entity.attributes ? entity.attributes[attribute] : null;
     }
 
     set hass(hass) {
@@ -215,38 +215,30 @@ class JbBatteryCard extends HTMLElement {
         const config = this._config;
 
         // --- Batterie 1 ---
-        const entityState1 = parseInt(this._getEntityStateValue(hass.states[config.entity], config.attribute1), 10) || '-';
+        const entityState1Raw = this._getEntityStateValue(hass.states[config.entity], config.attribute1);
+        const entityState1 = entityState1Raw !== null ? parseInt(entityState1Raw, 10) : '-';
         const statusEntityState1 = this._getEntityStateValue(hass.states[config.entity], config.status_attribute1);
         root.getElementById("percent1").textContent = `${entityState1}%`;
         root.getElementById("icon1").setAttribute("icon", this._computeBatteryIcon(entityState1, statusEntityState1));
         root.getElementById("icon1").style.color = this._computeColor(entityState1);
 
-        // Optionaler Wert 1 (Entladeleistung)
         if (config.value1_entity) {
-            let value1 = this._getEntityStateValue(hass.states[config.value1_entity]);
-            if (value1 && value1 != 0) {
-                root.getElementById("value1").textContent = `${value1} ${config.value1_unit || ''}`;
-            } else {
-                root.getElementById("value1").textContent = '';
-            }
+            const value1 = this._getEntityStateValue(hass.states[config.value1_entity]);
+            root.getElementById("value1").textContent = (value1 !== null && value1 !== undefined) ? `${value1} ${config.value1_unit || ''}` : '';
         }
 
         // --- Batterie 2 ---
         if (config.entity2) {
-            const entityState2 = parseInt(this._getEntityStateValue(hass.states[config.entity2], config.attribute2), 10) || '-';
+            const entityState2Raw = this._getEntityStateValue(hass.states[config.entity2], config.attribute2);
+            const entityState2 = entityState2Raw !== null ? parseInt(entityState2Raw, 10) : '-';
             const statusEntityState2 = this._getEntityStateValue(hass.states[config.entity2], config.status_attribute2);
             root.getElementById("percent2").textContent = `${entityState2}%`;
             root.getElementById("icon2").setAttribute("icon", this._computeBatteryIcon(entityState2, statusEntityState2));
             root.getElementById("icon2").style.color = this._computeColor(entityState2);
 
-            // Optionaler Wert 2 (Entladeleistung)
             if (config.value2_entity) {
-                let value2 = this._getEntityStateValue(hass.states[config.value2_entity]);
-                if (value2 && value2 != 0) {
-                    root.getElementById("value2").textContent = `${value2} ${config.value2_unit || ''}`;
-                } else {
-                    root.getElementById("value2").textContent = '';
-                }
+                const value2 = this._getEntityStateValue(hass.states[config.value2_entity]);
+                root.getElementById("value2").textContent = (value2 !== null && value2 !== undefined) ? `${value2} ${config.value2_unit || ''}` : '';
             }
         }
 

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -90,7 +90,7 @@ class JbBatteryCard extends HTMLElement {
         <div class="battery-block" id="battery1">
             <ha-icon id="icon1" icon="mdi:battery"></ha-icon>
             <div id="description1">
-                <span id="title1">${cardConfig.title1 || 'Sensor 1'}</span> 
+                <span id="title1">${cardConfig.title1}</span> 
                 <span id="percent1">-</span>
             </div>
         </div>
@@ -98,7 +98,7 @@ class JbBatteryCard extends HTMLElement {
         <div class="battery-block" id="battery2">
             <ha-icon id="icon2" icon="mdi:battery"></ha-icon>
             <div id="description2">
-                <span id="title2">${cardConfig.title2 || 'Sensor 2'}</span> 
+                <span id="title2">${cardConfig.title2}</span> 
                 <span id="percent2">-</span>
             </div>
         </div>` : ''}

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -2,16 +2,6 @@ const LitElement = Object.getPrototypeOf(
   customElements.get("ha-panel-lovelace")
 );
 
-const colors = {
-  0: "#bf360c",
-  10: "#c04807",
-  20: "#ab5c10",
-  30: "#ad6b0d",
-  40: "#827717",
-  60: "#33691e",
-  80: "#1b5e20"
-};
-
 class JbBatteryCard extends HTMLElement {
 
   constructor() {
@@ -35,8 +25,8 @@ class JbBatteryCard extends HTMLElement {
         display: flex;
         flex-direction: column;
         align-items: center;
-        justify-content: space-evenly;
-        padding: 10% 0;
+        justify-content: center;
+        padding: 12% 0;
         text-align: center;
         height: 100%;
       }
@@ -44,32 +34,40 @@ class JbBatteryCard extends HTMLElement {
       ha-icon {
         width: 40%;
         --mdc-icon-size: 100%;
+        margin-bottom: 6px;
       }
 
-      #description {
+      #text {
         display: flex;
         flex-direction: column;
         align-items: center;
+        gap: 2px;
+      }
+
+      .line {
+        display: block;
+        width: 100%;
       }
 
       #title {
         font-size: 0.9em;
-        opacity: 0.85;
+        opacity: 0.8;
       }
 
       #value {
         font-size: 1.4em;
         font-weight: bold;
-        display: block;
       }
     `;
 
     card.innerHTML = `
-      <ha-icon id="icon" icon="mdi:flash"></ha-icon>
-      <div id="description">
-        <div id="title"></div>
-        <div id="value"></div>
+      <ha-icon id="icon" icon="mdi:battery"></ha-icon>
+
+      <div id="text">
+        <div id="title" class="line"></div>
+        <div id="value" class="line"></div>
       </div>
+
       <mwc-ripple></mwc-ripple>
     `;
 
@@ -83,48 +81,31 @@ class JbBatteryCard extends HTMLElement {
   }
 
   _fire(type, detail) {
-    const event = new Event(type, {
-      bubbles: true,
-      composed: true
-    });
-    event.detail = detail;
-    this.shadowRoot.dispatchEvent(event);
+    const ev = new Event(type, { bubbles: true, composed: true });
+    ev.detail = detail;
+    this.shadowRoot.dispatchEvent(ev);
   }
 
   set hass(hass) {
+    const cfg = this._config;
     const root = this.shadowRoot;
-    const config = this._config;
-    const stateObj = hass.states[config.entity];
+    const stateObj = hass.states[cfg.entity];
     if (!stateObj) return;
 
-    const raw = config.attribute
-      ? stateObj.attributes[config.attribute]
+    const raw = cfg.attribute
+      ? stateObj.attributes[cfg.attribute]
       : stateObj.state;
 
     const unit = stateObj.attributes.unit_of_measurement || "";
     const valueText = `${raw} ${unit}`.trim();
 
-    // 🔴 ERZWUNGENER REFLOW (entscheidend!)
-    const valueEl = root.getElementById("value");
-    valueEl.textContent = "";
-    valueEl.offsetHeight; // <-- zwingt Browser zum Reflow
-    valueEl.textContent = valueText;
-
+    // 🔒 JEDER WERT EIGENE ZEILE – KEIN INLINE MEHR
     root.getElementById("title").textContent =
-      config.title || stateObj.attributes.friendly_name;
+      cfg.title || stateObj.attributes.friendly_name;
 
-    // Icon & Farbe nur wenn Zahl
-    const num = Number(raw);
-    if (!Number.isNaN(num)) {
-      root.getElementById("icon").style.color = this._computeColor(num);
-    }
+    root.getElementById("value").textContent = valueText;
 
     root.lastChild.hass = hass;
-  }
-
-  _computeColor(value) {
-    const keys = Object.keys(colors).map(Number).sort((a, b) => b - a);
-    return colors[keys.find(k => value >= k)] || "#999";
   }
 
   getCardSize() {
@@ -132,5 +113,4 @@ class JbBatteryCard extends HTMLElement {
   }
 }
 
-console.log("%c ⚡ jb-battery-card READY ", "background:#222;color:#bada55");
 customElements.define("jb-battery-card", JbBatteryCard);

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -224,7 +224,9 @@ class JbBatteryCard extends HTMLElement {
 
         if (config.value1_entity) {
             const value1 = this._getEntityStateValue(hass.states[config.value1_entity]);
-            root.getElementById("value1").textContent = (value1 !== null && value1 !== undefined) ? `${value1} ${config.value1_unit || ''}` : '';
+            root.getElementById("value1").textContent = (value1 !== null && value1 !== undefined) 
+                ? `${Math.round(value1)} ${config.value1_unit || ''}` 
+                : '';
         }
 
         // --- Batterie 2 ---
@@ -238,7 +240,9 @@ class JbBatteryCard extends HTMLElement {
 
             if (config.value2_entity) {
                 const value2 = this._getEntityStateValue(hass.states[config.value2_entity]);
-                root.getElementById("value2").textContent = (value2 !== null && value2 !== undefined) ? `${value2} ${config.value2_unit || ''}` : '';
+                root.getElementById("value2").textContent = (value2 !== null && value2 !== undefined) 
+                    ? `${Math.round(value2)} ${config.value2_unit || ''}` 
+                    : '';
             }
         }
 
@@ -250,5 +254,5 @@ class JbBatteryCard extends HTMLElement {
     }
 }
 
-console.log("%c 🪫 jb-battery-card (2 Sensors + optional value + unit) ", "background: #222; color: #bada55");
+console.log("%c 🪫 jb-battery-card (2 Sensors + optional value + unit, integer display) ", "background: #222; color: #bada55");
 customElements.define("jb-battery-card", JbBatteryCard);

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -73,7 +73,7 @@ class JbBatteryCard extends HTMLElement {
           }
             
           ha-icon {
-              width: 40%;
+              width: 80%;
               height: auto;
               --mdc-icon-size: 100%;
           }

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -44,12 +44,17 @@ class JbBatteryCard extends HTMLElement {
         cardConfig.entity = entityParts.entity;
         if (entityParts.attribute) cardConfig.attribute1 = entityParts.attribute;
 
+        // Optionaler Wert 1 (Entladeleistung)
+        if (!cardConfig.value1_entity) cardConfig.value1_entity = null;
+
         // Entity 2 (optional)
         let entity2Parts = null;
         if (cardConfig.entity2) {
             entity2Parts = this._splitEntityAndAttribute(cardConfig.entity2);
             cardConfig.entity2 = entity2Parts.entity;
             if (entity2Parts.attribute) cardConfig.attribute2 = entity2Parts.attribute;
+
+            if (!cardConfig.value2_entity) cardConfig.value2_entity = null;
         }
 
         const card = document.createElement("ha-card");
@@ -87,14 +92,21 @@ class JbBatteryCard extends HTMLElement {
               align-items: center;
               margin: 0 10px;
           }
+
+          .extra-value {
+              font-size: 0.9em;
+              color: var(--primary-text-color);
+              margin: 2px 0;
+          }
         `;
 
-        // HTML mit optionalen Titeln
+        // HTML mit optionalen Titeln und extra Wert
         card.innerHTML = `
         <div class="battery-block" id="battery1">
             <ha-icon id="icon1" icon="mdi:battery"></ha-icon>
             <div id="description1">
                 ${cardConfig.title1 ? `<span id="title1">${cardConfig.title1}</span>` : ''}
+                <span class="extra-value" id="value1"></span>
                 <span id="percent1">-</span>
             </div>
         </div>
@@ -103,6 +115,7 @@ class JbBatteryCard extends HTMLElement {
             <ha-icon id="icon2" icon="mdi:battery"></ha-icon>
             <div id="description2">
                 ${cardConfig.title2 ? `<span id="title2">${cardConfig.title2}</span>` : ''}
+                <span class="extra-value" id="value2"></span>
                 <span id="percent2">-</span>
             </div>
         </div>` : ''}
@@ -199,22 +212,32 @@ class JbBatteryCard extends HTMLElement {
         const root = this.shadowRoot;
         const config = this._config;
 
-        // Entity 1
+        // --- Batterie 1 ---
         const entityState1 = parseInt(this._getEntityStateValue(hass.states[config.entity], config.attribute1), 10) || '-';
         const statusEntityState1 = this._getEntityStateValue(hass.states[config.entity], config.status_attribute1);
-
         root.getElementById("percent1").textContent = `${entityState1}%`;
         root.getElementById("icon1").setAttribute("icon", this._computeBatteryIcon(entityState1, statusEntityState1));
         root.getElementById("icon1").style.color = this._computeColor(entityState1);
 
-        // Entity 2
+        // Optionaler Wert 1 (Entladeleistung)
+        if (config.value1_entity) {
+            const value1 = this._getEntityStateValue(hass.states[config.value1_entity]);
+            root.getElementById("value1").textContent = (value1 && value1 != 0) ? value1 : '';
+        }
+
+        // --- Batterie 2 ---
         if (config.entity2) {
             const entityState2 = parseInt(this._getEntityStateValue(hass.states[config.entity2], config.attribute2), 10) || '-';
             const statusEntityState2 = this._getEntityStateValue(hass.states[config.entity2], config.status_attribute2);
-
             root.getElementById("percent2").textContent = `${entityState2}%`;
             root.getElementById("icon2").setAttribute("icon", this._computeBatteryIcon(entityState2, statusEntityState2));
             root.getElementById("icon2").style.color = this._computeColor(entityState2);
+
+            // Optionaler Wert 2 (Entladeleistung)
+            if (config.value2_entity) {
+                const value2 = this._getEntityStateValue(hass.states[config.value2_entity]);
+                root.getElementById("value2").textContent = (value2 && value2 != 0) ? value2 : '';
+            }
         }
 
         root.lastChild.hass = hass;
@@ -225,5 +248,5 @@ class JbBatteryCard extends HTMLElement {
     }
 }
 
-console.log("%c 🪫 jb-battery-card (2 Sensors) ", "background: #222; color: #bada55");
+console.log("%c 🪫 jb-battery-card (2 Sensors + optional value) ", "background: #222; color: #bada55");
 customElements.define("jb-battery-card", JbBatteryCard);

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -214,8 +214,8 @@ class JbBatteryCard extends HTMLElement {
     _formatValueWithArrow(value) {
         if (value === null || value === undefined) return '';
         const rounded = Math.round(value);
-        if (rounded < 0) return `↑${Math.abs(rounded)}`;
-        if (rounded > 0) return `↓${rounded}`;
+        if (rounded < 0) return `↓${Math.abs(rounded)}`;
+        if (rounded > 0) return `↑${rounded}`;
         return `${rounded}`;
     }
 

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -90,7 +90,7 @@ class JbBatteryCard extends HTMLElement {
         <div class="battery-block" id="battery1">
             <ha-icon id="icon1" icon="mdi:battery"></ha-icon>
             <div id="description1">
-                <span id="title1">${cardConfig.title1}</span> 
+                ${cardConfig.title1 ? `<span id="title1">${cardConfig.title1}</span>` : ''}
                 <span id="percent1">-</span>
             </div>
         </div>
@@ -98,12 +98,13 @@ class JbBatteryCard extends HTMLElement {
         <div class="battery-block" id="battery2">
             <ha-icon id="icon2" icon="mdi:battery"></ha-icon>
             <div id="description2">
-                <span id="title2">${cardConfig.title2}</span> 
+                ${cardConfig.title2 ? `<span id="title2">${cardConfig.title2}</span>` : ''}
                 <span id="percent2">-</span>
             </div>
         </div>` : ''}
         <mwc-ripple></mwc-ripple>
         `;
+
 
         card.appendChild(style);
 

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -1,267 +1,163 @@
 const LitElement = Object.getPrototypeOf(
-    customElements.get("ha-panel-lovelace")
+  customElements.get("ha-panel-lovelace")
 );
-const html = LitElement.prototype.html;
 
 const colors = {
-    0: "#bf360c",
-    10: "#c04807",
-    20: "#ab5c10",
-    30: "#ad6b0d",
-    40: "#827717",
-    60: "#33691e",
-    80: "#1b5e20"
+  0: "#bf360c",
+  10: "#c04807",
+  20: "#ab5c10",
+  30: "#ad6b0d",
+  40: "#827717",
+  60: "#33691e",
+  80: "#1b5e20"
 };
 
 const simpleColors = {
-    0: "#bf360c",
-    15: "#ad6b0d",
-    33: "#827717",
-    66: "#1b5e20"
+  0: "#bf360c",
+  15: "#ad6b0d",
+  33: "#827717",
+  66: "#1b5e20"
 };
 
 class JbBatteryCard extends HTMLElement {
 
-    constructor() {
-        super();
-        this.attachShadow({ mode: "open" });
-        this.colorMap = colors;
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.colorMap = colors;
+  }
+
+  setConfig(config) {
+    if (!config.entity) {
+      throw new Error("Please define an entity");
     }
 
-    setConfig(config) {
-        if (!config.entity) {
-            throw new Error("Please define entity");
-        }
+    const root = this.shadowRoot;
+    root.innerHTML = "";
 
-        const root = this.shadowRoot;
-        if (root.lastChild) root.removeChild(root.lastChild);
+    const cardConfig = { ...config };
+    if (!cardConfig.scale) cardConfig.scale = "50px";
 
-        const cardConfig = Object.assign({}, config);
-        if (!cardConfig.scale) cardConfig.scale = "50px";
+    const entityParts = this._splitEntityAndAttribute(cardConfig.entity);
+    cardConfig.entity = entityParts.entity;
+    if (entityParts.attribute) cardConfig.attribute = entityParts.attribute;
 
-        // Entity 1
-        const entityParts = this._splitEntityAndAttribute(cardConfig.entity);
-        cardConfig.entity = entityParts.entity;
-        if (entityParts.attribute) cardConfig.attribute1 = entityParts.attribute;
+    const card = document.createElement("ha-card");
 
-        // Optionaler Wert 1 (Entladeleistung)
-        if (!cardConfig.value1_entity) cardConfig.value1_entity = null;
-        if (!cardConfig.value1_unit) cardConfig.value1_unit = '';
+    const style = document.createElement("style");
+    style.textContent = `
+      ha-card {
+        cursor: pointer;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: space-evenly;
+        padding: 8% 0;
+        text-align: center;
+        height: 100%;
+      }
 
-        // Entity 2 (optional)
-        let entity2Parts = null;
-        if (cardConfig.entity2) {
-            entity2Parts = this._splitEntityAndAttribute(cardConfig.entity2);
-            cardConfig.entity2 = entity2Parts.entity;
-            if (entity2Parts.attribute) cardConfig.attribute2 = entity2Parts.attribute;
+      ha-icon {
+        width: 40%;
+        --mdc-icon-size: 100%;
+      }
 
-            if (!cardConfig.value2_entity) cardConfig.value2_entity = null;
-            if (!cardConfig.value2_unit) cardConfig.value2_unit = '';
-        }
+      #description {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        line-height: 1.25;
+      }
 
-        const card = document.createElement("ha-card");
-        card.setAttribute("id", "card");
-        card.setAttribute("aria-label", cardConfig.title || "");
+      #title {
+        font-size: 0.9em;
+        opacity: 0.85;
+      }
 
-        // Dynamische Icon-Größe: 1 Batterie → 40%, 2 Batterien → 80%
-        const iconSize = cardConfig.entity2 ? '80%' : '40%';
+      #value {
+        font-size: 1.4em;
+        font-weight: bold;
+        white-space: nowrap;
+      }
+    `;
 
-        const style = document.createElement("style");
-        style.textContent = `
-          ha-card {
-            --base-unit: ${cardConfig.scale};
-            cursor: pointer;
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-            text-align: center;
-            padding: 4% 0px;
-            font-size: 16.8px;
-            box-sizing: border-box;
-            justify-content: space-evenly;
-            height: 100%;
-          }
-            
-          ha-icon {
-              width: ${iconSize};
-              height: auto;
-              --mdc-icon-size: 100%;
-          }
-          
-          .battery-block {
-              display: flex;
-              flex-direction: column;
-              align-items: center;
-              margin: 0 10px;
-          }
+    card.innerHTML = `
+      <ha-icon id="icon" icon="mdi:battery"></ha-icon>
+      <div id="description">
+        <div id="title"></div>
+        <div id="value"></div>
+      </div>
+      <mwc-ripple></mwc-ripple>
+    `;
 
-          .extra-value {
-              font-size: 0.9em;
-              color: var(--primary-text-color);
-              margin: 2px 0;
-          }
-        `;
+    card.appendChild(style);
 
-        // HTML mit optionalen Titeln und extra Wert
-        card.innerHTML = `
-        <div class="battery-block" id="battery1">
-            <ha-icon id="icon1" icon="mdi:battery"></ha-icon>
-            <div id="description1">
-                ${cardConfig.title1 ? `<span id="title1">${cardConfig.title1}</span>` : ''}
-                <span class="extra-value" id="value1"></span>
-                <span id="percent1">-</span>
-            </div>
-        </div>
-        ${cardConfig.entity2 ? `
-        <div class="battery-block" id="battery2">
-            <ha-icon id="icon2" icon="mdi:battery"></ha-icon>
-            <div id="description2">
-                ${cardConfig.title2 ? `<span id="title2">${cardConfig.title2}</span>` : ''}
-                <span class="extra-value" id="value2"></span>
-                <span id="percent2">-</span>
-            </div>
-        </div>` : ''}
-        <mwc-ripple></mwc-ripple>
-        `;
+    card.addEventListener("click", () => {
+      this._fire("hass-more-info", { entityId: cardConfig.entity });
+    });
 
-        card.appendChild(style);
+    root.appendChild(card);
 
-        // Klick auf Batterie 1
-        card.querySelector("#battery1").addEventListener("click", event => {
-            this._fire("hass-more-info", { entityId: cardConfig.entity });
-        });
+    this._config = cardConfig;
+  }
 
-        // Klick auf Batterie 2
-        if (cardConfig.entity2) {
-            card.querySelector("#battery2").addEventListener("click", event => {
-                this._fire("hass-more-info", { entityId: cardConfig.entity2 });
-            });
-        }
+  _splitEntityAndAttribute(entity) {
+    const parts = entity.split(".");
+    if (parts.length < 3) return { entity };
+    return { entity: parts.slice(0, -1).join("."), attribute: parts.at(-1) };
+  }
 
-        root.appendChild(card);
+  _fire(type, detail) {
+    const event = new Event(type, {
+      bubbles: true,
+      composed: true
+    });
+    event.detail = detail;
+    this.shadowRoot.dispatchEvent(event);
+  }
 
-        // Farbskala
-        if (cardConfig.colors) {
-            this.colorMap = cardConfig.colors;
-        } else if (cardConfig.variant == "simple") {
-            this.colorMap = simpleColors;
-        } else {
-            this.colorMap = colors;
-        }
+  set hass(hass) {
+    const config = this._config;
+    const root = this.shadowRoot;
 
-        this._config = cardConfig;
+    const stateObj = hass.states[config.entity];
+    if (!stateObj) return;
+
+    let rawValue = config.attribute
+      ? stateObj.attributes[config.attribute]
+      : stateObj.state;
+
+    const numberValue = Number(rawValue);
+    const isValidNumber = !Number.isNaN(numberValue);
+
+    const unit = stateObj.attributes.unit_of_measurement || "";
+
+    const displayValue = isValidNumber
+      ? `${numberValue} ${unit}`.trim()
+      : rawValue;
+
+    root.getElementById("title").textContent =
+      config.title || stateObj.attributes.friendly_name;
+
+    root.getElementById("value").textContent = displayValue;
+
+    const icon = root.getElementById("icon");
+    if (isValidNumber) {
+      icon.style.color = this._computeColor(numberValue);
     }
 
-    _splitEntityAndAttribute(entity) {
-        let parts = entity.split(".");
-        if (parts.length < 3) {
-            return { entity: entity };
-        }
-        return { attribute: parts.pop(), entity: parts.join(".") };
-    }
+    root.lastChild.hass = hass;
+  }
 
-    _fire(type, detail, options) {
-        const node = this.shadowRoot;
-        options = options || {};
-        detail = (detail === null || detail === undefined) ? {} : detail;
-        const event = new Event(type, {
-            bubbles: options.bubbles === undefined ? true : options.bubbles,
-            cancelable: Boolean(options.cancelable),
-            composed: options.composed === undefined ? true : options.composed
-        });
-        event.detail = detail;
-        node.dispatchEvent(event);
-        return event;
-    }
+  _computeColor(value) {
+    const keys = Object.keys(this.colorMap).map(Number).sort((a, b) => b - a);
+    return this.colorMap[keys.find(k => value >= k)] || "#999";
+  }
 
-    _computeColor(stateValue) {
-        let numberValue = Number(stateValue);
-        let colorLevels = Object.keys(this.colorMap).sort((a,b) => b-a);
-        let key = colorLevels.find(key => numberValue >= key);
-        return this.colorMap[key];
-    }
-
-    _computeBatteryIconSimple(value, state) {
-        let statePart = (state === "charging" || state === "full") ? "-charging" : "";
-        let level = +value;
-        if (level <= 15) return `mdi:battery${statePart}-outline`;
-        if (level <= 45) return `mdi:battery${statePart}-low`;
-        if (level <= 80) return `mdi:battery${statePart}-medium`;
-        return `mdi:battery${statePart}-high`;
-    }
-
-    _computeBatteryIconDetailed(value, state) {
-        let statePart = (state === "charging" || state === "full") ? "-charging" : "";
-        let numberValue = +value;
-        let level = Math.round(numberValue / 10) * 10;
-        if (level == 0) return `mdi:battery${statePart}-outline`;
-        if (level < 100) return `mdi:battery${statePart}-${level}`;
-        return (state === "charging" || state === "full") ? `mdi:battery-charging-100` : `mdi:battery${statePart}`;
-    }
-
-    _computeBatteryIcon(value, state) {
-        if (this._config.variant == "simple") return this._computeBatteryIconSimple(value, state);
-        return this._computeBatteryIconDetailed(value, state);
-    }
-
-    _getEntityStateValue(entity, attribute) {
-        if (!entity) return null;
-        if (!attribute) return entity.state;
-        return entity.attributes ? entity.attributes[attribute] : null;
-    }
-
-    // --- Funktion um Wert mit Pfeil anzuzeigen ---
-    _formatValueWithArrow(value) {
-        if (value === null || value === undefined) return '';
-        const rounded = Math.round(value);
-        if (rounded < 0) return `↑${Math.abs(rounded)}`;
-        if (rounded > 0) return `↓${rounded}`;
-        return `${rounded}`;
-    }
-
-    set hass(hass) {
-        const root = this.shadowRoot;
-        const config = this._config;
-
-        // --- Batterie 1 ---
-        const entityState1Raw = this._getEntityStateValue(hass.states[config.entity], config.attribute1);
-        const entityState1 = entityState1Raw !== null ? parseInt(entityState1Raw, 10) : '-';
-        const statusEntityState1 = this._getEntityStateValue(hass.states[config.entity], config.status_attribute1);
-        root.getElementById("percent1").textContent = `${entityState1}%`;
-        root.getElementById("icon1").setAttribute("icon", this._computeBatteryIcon(entityState1, statusEntityState1));
-        root.getElementById("icon1").style.color = this._computeColor(entityState1);
-
-        if (config.value1_entity) {
-            const value1 = this._getEntityStateValue(hass.states[config.value1_entity]);
-            root.getElementById("value1").textContent = (value1 !== null && value1 !== undefined) 
-                ? `${this._formatValueWithArrow(value1)}${config.value1_unit || ''}` 
-                : '';
-        }
-
-        // --- Batterie 2 ---
-        if (config.entity2) {
-            const entityState2Raw = this._getEntityStateValue(hass.states[config.entity2], config.attribute2);
-            const entityState2 = entityState2Raw !== null ? parseInt(entityState2Raw, 10) : '-';
-            const statusEntityState2 = this._getEntityStateValue(hass.states[config.entity2], config.status_attribute2);
-            root.getElementById("percent2").textContent = `${entityState2}%`;
-            root.getElementById("icon2").setAttribute("icon", this._computeBatteryIcon(entityState2, statusEntityState2));
-            root.getElementById("icon2").style.color = this._computeColor(entityState2);
-
-            if (config.value2_entity) {
-                const value2 = this._getEntityStateValue(hass.states[config.value2_entity]);
-                root.getElementById("value2").textContent = (value2 !== null && value2 !== undefined) 
-                    ? `${this._formatValueWithArrow(value2)}${config.value2_unit || ''}` 
-                    : '';
-            }
-        }
-
-        root.lastChild.hass = hass;
-    }
-
-    getCardSize() {
-        return 1;
-    }
+  getCardSize() {
+    return 1;
+  }
 }
 
-console.log("%c 🪫 jb-battery-card (2 Sensors + optional value + unit, arrows for +/-) ", "background: #222; color: #bada55");
+console.log("%c 🔋 jb-battery-card loaded ", "background:#222;color:#bada55");
 customElements.define("jb-battery-card", JbBatteryCard);

--- a/jb-battery-card.js
+++ b/jb-battery-card.js
@@ -46,6 +46,7 @@ class JbBatteryCard extends HTMLElement {
 
         // Optionaler Wert 1 (Entladeleistung)
         if (!cardConfig.value1_entity) cardConfig.value1_entity = null;
+        if (!cardConfig.value1_unit) cardConfig.value1_unit = '';
 
         // Entity 2 (optional)
         let entity2Parts = null;
@@ -55,6 +56,7 @@ class JbBatteryCard extends HTMLElement {
             if (entity2Parts.attribute) cardConfig.attribute2 = entity2Parts.attribute;
 
             if (!cardConfig.value2_entity) cardConfig.value2_entity = null;
+            if (!cardConfig.value2_unit) cardConfig.value2_unit = '';
         }
 
         const card = document.createElement("ha-card");
@@ -221,8 +223,12 @@ class JbBatteryCard extends HTMLElement {
 
         // Optionaler Wert 1 (Entladeleistung)
         if (config.value1_entity) {
-            const value1 = this._getEntityStateValue(hass.states[config.value1_entity]);
-            root.getElementById("value1").textContent = (value1 && value1 != 0) ? value1 : '';
+            let value1 = this._getEntityStateValue(hass.states[config.value1_entity]);
+            if (value1 && value1 != 0) {
+                root.getElementById("value1").textContent = `${value1} ${config.value1_unit || ''}`;
+            } else {
+                root.getElementById("value1").textContent = '';
+            }
         }
 
         // --- Batterie 2 ---
@@ -235,8 +241,12 @@ class JbBatteryCard extends HTMLElement {
 
             // Optionaler Wert 2 (Entladeleistung)
             if (config.value2_entity) {
-                const value2 = this._getEntityStateValue(hass.states[config.value2_entity]);
-                root.getElementById("value2").textContent = (value2 && value2 != 0) ? value2 : '';
+                let value2 = this._getEntityStateValue(hass.states[config.value2_entity]);
+                if (value2 && value2 != 0) {
+                    root.getElementById("value2").textContent = `${value2} ${config.value2_unit || ''}`;
+                } else {
+                    root.getElementById("value2").textContent = '';
+                }
             }
         }
 
@@ -248,5 +258,5 @@ class JbBatteryCard extends HTMLElement {
     }
 }
 
-console.log("%c 🪫 jb-battery-card (2 Sensors + optional value) ", "background: #222; color: #bada55");
+console.log("%c 🪫 jb-battery-card (2 Sensors + optional value + unit) ", "background: #222; color: #bada55");
 customElements.define("jb-battery-card", JbBatteryCard);


### PR DESCRIPTION
This are the new possibilities for configuration in dashboard:
```
type: custom:jb-battery-card
entity: sensor.battery_soc1
entity2: sensor.battery_soc2
title1: null
value1_entity: sensor.power1
value1_unit: W
title2: null
value2_entity: sensor.power2
value2_unit: W
horizontal: true
variant: simple
colors:
  "0": "#FF0000"
  "33": "#ff961f"
  "80": "#008000"
```

Change looks like this:

<img width="170" height="122" alt="Bildschirmfoto 2026-01-22 um 23 35 08" src="https://github.com/user-attachments/assets/6f02cb10-63e1-4c94-82b1-c87d2ee8a949" />

